### PR TITLE
adgenerationBidAdapter: Set mediaType=BANNER for banner bids, bump ve…

### DIFF
--- a/modules/adgenerationBidAdapter.js
+++ b/modules/adgenerationBidAdapter.js
@@ -16,7 +16,7 @@ const adgLogger = prefixLog('Adgeneration: ');
  */
 
 const ADG_BIDDER_CODE = 'adgeneration';
-const ADGENE_PREBID_VERSION = '1.6.5';
+const ADGENE_PREBID_VERSION = '1.6.6';
 const DEBUG_URL = 'https://api-test.scaleout.jp/adgen/prebid';
 const URL = 'https://d.socdm.com/adgen/prebid';
 
@@ -154,6 +154,7 @@ export const spec = {
     } else {
       // banner
       bidResponse.ad = createAd(adResult, body?.location_params, targetImp.ext.params, requestId);
+      bidResponse.mediaType = BANNER;
     }
     return [bidResponse];
   },

--- a/test/spec/modules/adgenerationBidAdapter_spec.js
+++ b/test/spec/modules/adgenerationBidAdapter_spec.js
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
 import { spec } from 'modules/adgenerationBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
-import { NATIVE } from 'src/mediaTypes.js';
+import { BANNER, NATIVE } from 'src/mediaTypes.js';
 import prebid from 'package.json';
 import { setConfig as setCurrencyConfig } from '../../../modules/currency.js';
 import { addFPDToBidderRequest } from '../../helpers/fpd.js';
 
 describe('AdgenerationAdapter', function () {
   const adapter = newBidder(spec);
-  const ADGENE_PREBID_VERSION = '1.6.5';
+  const ADGENE_PREBID_VERSION = '1.6.6';
   const ENDPOINT_STG = 'https://api-test.scaleout.jp/adgen/prebid';
   const ENDPOINT_RELEASE = 'https://d.socdm.com/adgen/prebid';
 
@@ -1127,7 +1127,8 @@ describe('AdgenerationAdapter', function () {
           netRevenue: true,
           ttl: 1000,
           ad: '<div></div>',
-          adomain: ['advertiserdomain.com']
+          adomain: ['advertiserdomain.com'],
+          mediaType: BANNER
         },
         native: {
           requestId: '2f6ac468a9c15e',
@@ -1174,7 +1175,8 @@ describe('AdgenerationAdapter', function () {
           netRevenue: true,
           ttl: 1000,
           ad: `<script type="text/javascript" src="https://i.socdm.com/sdk/js/adg-browser-m.js"></script><script type="text/javascript">window.ADGBrowserM.init({vastXml: '<?xml version="1.0" encoding="UTF-8" standalone="no" ?><VAST version="3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd"></VAST>', marginTop: '50'});</script><img src="http://example.com" width="1" height="1" style="display:none;border:none;padding:0;margin:0;width:1px;height:1px"/>`,
-          adomain: ['advertiserdomain.com']
+          adomain: ['advertiserdomain.com'],
+          mediaType: BANNER
         },
       }
     };
@@ -1205,6 +1207,7 @@ describe('AdgenerationAdapter', function () {
         expect(result.netRevenue).to.equal(bidResponses.normal.upperBillboard.netRevenue);
         expect(result.ttl).to.equal(bidResponses.normal.upperBillboard.ttl);
         expect(result.ad).to.equal(bidResponses.normal.upperBillboard.ad);
+        expect(result.mediaType).to.equal(BANNER);
         setCurrencyConfig({});
       });
     });
@@ -1220,6 +1223,7 @@ describe('AdgenerationAdapter', function () {
       expect(result.netRevenue).to.equal(bidResponses.normal.banner.netRevenue);
       expect(result.ttl).to.equal(bidResponses.normal.banner.ttl);
       expect(result.ad).to.equal(bidResponses.normal.banner.ad);
+      expect(result.mediaType).to.equal(BANNER);
       // no adomian
       expect(result).to.not.have.any.keys('meta');
       expect(result).to.not.have.any.keys('advertiserDomains');
@@ -1266,6 +1270,7 @@ describe('AdgenerationAdapter', function () {
       expect(result.netRevenue).to.equal(bidResponses.normal.banner.netRevenue);
       expect(result.ttl).to.equal(bidResponses.normal.banner.ttl);
       expect(result.ad).to.equal(bidResponses.normal.banner.ad);
+      expect(result.mediaType).to.equal(BANNER);
       // no adomain
       expect(result).to.not.have.any.keys('meta');
       expect(result).to.not.have.any.keys('advertiserDomains');


### PR DESCRIPTION
version to 1.6.6

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Set `bidResponse.mediaType = BANNER` explicitly for banner bids in `adgenerationBidAdapter`.

  Previously, only native bids had `mediaType` set (`NATIVE`), while banner bids relied on Prebid's default assumption that bids without
  `mediaType` are banner.

  Since Prebid.js 11.0.0, publishers can enable `auctionOptions.rejectUnknownMediaTypes: true`, which rejects bids without an explicit
  `mediaType`. This change ensures ADGeneration banner bids are not rejected in that configuration.

  Also bumps `ADGENE_PREBID_VERSION` from `1.6.5` to `1.6.6`.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
  Related release: Prebid.js 11.0.0
  > Bids that do not declare any `mediaType` are assumed to be `'banner'`
